### PR TITLE
Copy scheduled sessions from one recorder to another

### DIFF
--- a/scheduler/static/scheduler/css/mobile.less
+++ b/scheduler/static/scheduler/css/mobile.less
@@ -191,6 +191,10 @@ span.loading {
 
 }//.tab-content
 
+#panopto-recorders {
+    .rooms-loading { position: absolute; display: inline-block; margin-left: 150px; font-size: 20px; height: 40px; width: 40x;  }
+    select#room-select { width: 16em; }
+}
 
 /*** Search result block ***/
 .result-display-container{ padding:0px;

--- a/scheduler/static/scheduler/css/mobile.less
+++ b/scheduler/static/scheduler/css/mobile.less
@@ -194,6 +194,7 @@ span.loading {
 #panopto-recorders {
     .rooms-loading { position: absolute; display: inline-block; margin-left: 150px; font-size: 20px; height: 40px; width: 40x;  }
     select#room-select { width: 16em; }
+    .batchswitch .schedule-duration, .batchswitch .dropdown-container { visibility: hidden; }
 }
 
 /*** Search result block ***/

--- a/scheduler/static/scheduler/js/main.js
+++ b/scheduler/static/scheduler/js/main.js
@@ -494,7 +494,7 @@ var PanoptoScheduler = (function ($) {
     }
 
     function recorder_select_failure(xhr) {
-        $(".event-search-result").empty();
+        $(".recorder-select-result").empty();
         failure_modal('Recorder Search Failure',
                       'Please try again later.',
                       xhr);
@@ -648,7 +648,7 @@ var PanoptoScheduler = (function ($) {
             url: panopto_api_path('recorder/', { timeout: 0 }),
             complete: room_search_complete
         })
-            .fail(event_search_failure)
+            .fail(recorder_select_failure)
             .done(init_room_select);
     }
 
@@ -1311,7 +1311,7 @@ var PanoptoScheduler = (function ($) {
             contentType: 'application/json',
             data: JSON.stringify(request_data)
         }).fail(function (xhr) {
-            failure_modal('Cannot Schedule Recording',
+            failure_modal('Cannot Update Recorder',
                           'Please try again later.',
                           xhr);
         }).done(function () {

--- a/scheduler/static/scheduler/js/main.js
+++ b/scheduler/static/scheduler/js/main.js
@@ -567,6 +567,21 @@ var PanoptoScheduler = (function ($) {
 
     }
 
+    function do_scheduled_recording_search(session_ids) {
+        $.ajax({
+            type: 'GET',
+            url: panopto_api_path('schedule/', {
+                session_ids: session_ids,
+            }),
+            waitIndicatator: event_search_in_progress,
+            complete: event_search_complete
+        })
+            .fail(event_search_failure)
+            .done(function (msg) {
+                paint_space_schedule(msg);
+            });
+    }
+
     function update_term_selector() {
         $('#selected-quarter').html($("option:selected", this).text());
     }
@@ -1245,6 +1260,8 @@ var PanoptoScheduler = (function ($) {
             };
 
         $('.result-display-container').html(tpl(context));
+
+        do_scheduled_recording_search(data[0].scheduled_recordings);
     }
 
     function panopto_recorder_search() {

--- a/scheduler/static/scheduler/js/main.js
+++ b/scheduler/static/scheduler/js/main.js
@@ -1031,13 +1031,16 @@ var PanoptoScheduler = (function ($) {
 
         $('.list-group .btn-group.unscheduled > button:first-child').not(':disabled').each(function () {
             pe = panopto_event($(this));
-            pe.recording.is_broadcast = webcast;
-            pe.recording.is_public = is_public;
 
-            if (vals) {
-                start = moment(pe.event.start).add(start_delta, 'seconds');
-                pe.recording.start = start.toISOString();
-                pe.recording.end = start.add(duration, 'seconds').toISOString();
+            if (!$('#panopto-recorders').length) {
+                pe.recording.is_broadcast = webcast;
+                pe.recording.is_public = is_public;
+
+                if (vals) {
+                    start = moment(pe.event.start).add(start_delta, 'seconds');
+                    pe.recording.start = start.toISOString();
+                    pe.recording.end = start.add(duration, 'seconds').toISOString();
+                }
             }
 
             schedule_panopto_recording(pe);

--- a/scheduler/templates/scheduler/recorders.html
+++ b/scheduler/templates/scheduler/recorders.html
@@ -66,6 +66,20 @@
   
   {{/each}}
 
+  {{#if space}}
+  <div class="room-header"><!-- Rslt Header -->
+      <form role="form" class="form-inline event-search">
+          <div class="form-group inputs-row">
+              <label for="import-select" class="">Copy schedule from:</label>
+              <div class="rooms-loading"><i class="fa fa-spinner fa-spin"></i></div>
+              <select id="import-select" type="text" class="form-control input-rm">
+                  <option value="" title="select a recorder">Select a Recorder</option>
+              </select>
+          </div>
+      </form>
+  </div>	<!-- .Rslt Header -->
+  {{/if}}
+
   <div class="event-search">
     <div class="result-display-container event-search-result"></div>
   </div>
@@ -82,6 +96,11 @@
 	    {{else}}
 		<span class="record-status-disable-outer"><i class="fa fa-warning"></i><span class="record-status-disable">No recorder found in this room</span></span>
 	    {{/if}}
+        {{#if has_recorder}}
+        <div class="pull-right clearfix batchswitch">
+          {{> schedule-button}}
+        </div>
+        {{/if}}
     </div>
 
     {{> reservation-list}}

--- a/scheduler/templates/scheduler/recorders.html
+++ b/scheduler/templates/scheduler/recorders.html
@@ -65,9 +65,65 @@
   {{#each scheduled_recordings}}
   
   {{/each}}
+
+  <div class="event-search">
+    <div class="result-display-container event-search-result"></div>
+  </div>
 </div>
 {% endtplhandlebars %}
 
+{% tplhandlebars "event-search-result-template" %}
+  <div class="result-list-container">
+    <div class="result-header">
+        <span class="sr-only">Schedule in {{room}}</span>
+        <span class="sr-only">Lecture capture recording status: </span>
+        {{#if has_recorder}}
+	    <span class="record-status-enable"><i class="fa fa-video-camera"></i> Recorder is ready in this room</span>
+	    {{else}}
+		<span class="record-status-disable-outer"><i class="fa fa-warning"></i><span class="record-status-disable">No recorder found in this room</span></span>
+	    {{/if}}
+    </div>
+
+    {{> reservation-list}}
+
+  </div>
+{% endtplhandlebars %}
+
+
+{% tplhandlebars "event-search-result-empty-template" %}
+  <div class="room-header"><!-- Rslt Header -->
+	<h3>No events scheduled on this recorder</h3>
+  </div>	<!-- .Rslt Header -->
+{% endtplhandlebars %}
+
+{% tplhandlebars "reservation-list-partial" %}
+  <ol class="list-group result-list-chunk">
+    {{#each schedule}}
+      <li class="list-group-item clearfix">
+        <span class="result-row-date" title="date">{{ month_num }}/{{ day }}</span>
+        <span class="result-row-day" title="day">{{ weekday }}</span>
+        <span class="result-row-time" title="time">{{ event_start_time }} - {{ event_end_time }} {{ ampm }}</span>
+        <span class="result-row-event meeting-room-{{ name_index }}" title="event name">{{ name }}</span>
+        <span class="result-row-contact" title="Contact person">
+          {{#if contact_email}}
+            <a href="mailto:{{ contact_email }}" target="_blank">{{ contact }}</a>
+          {{else}}
+            {{ contact }}
+          {{/if}}
+        </span>
+        {{#if has_recorder}}
+        <!--Button Code-->
+        <span class="pull-right result-row-switchbtn">
+        {{> schedule-button}}
+        </span>
+        <!--End button-->
+        {{/if}}
+      </li>
+    {{/each}}
+  </ol>
+{% endtplhandlebars %}
+
+{% include "scheduler/handlebars/schedule_button_partial.html" %}
 
 {% tplhandlebars "ajax-waiting" %}
   <div class="waiting">
@@ -164,6 +220,7 @@ window.scheduler = {
 {% block extra_js %}
 {% compress js %}
 <script src="{% static "vendor/js/moment.min.js" %}"></script>
+<script src="{% static "vendor/js/bootstrap-slider.min.js" %}"></script>
 <script src="{% static "scheduler/js/main.js" %}"></script>
 {% endcompress %}
 {% endblock extra_js %}

--- a/scheduler/templates/scheduler/recorders.html
+++ b/scheduler/templates/scheduler/recorders.html
@@ -30,7 +30,7 @@
 <hr>
 
 {% tplhandlebars "recorder-selection-tmpl" %}
-<div class="container">
+<div class="result-list-container">
   <div class="recorder-selection" role="form">
     <div class="form-group">
       <label for="recorder-name">Name</label>

--- a/scheduler/utils/session.py
+++ b/scheduler/utils/session.py
@@ -6,3 +6,10 @@ def get_sessions_by_external_ids(external_ids):
     sessions = api.getSessionsByExternalId(external_ids)
     return sessions.Session if (sessions and 'Session' in sessions and
                                 len(sessions.Session)) else None
+
+
+def get_sessions_by_session_ids(session_ids):
+    api = SessionManagement()
+    sessions = api.getSessionsById(session_ids)
+    return sessions.Session if (sessions and 'Session' in sessions and
+                                len(sessions.Session)) else None

--- a/scheduler/views/api/session.py
+++ b/scheduler/views/api/session.py
@@ -144,6 +144,12 @@ class Session(RESTDispatch):
 
     def _valid_folder(self, name, external_id):
         try:
+            folder_id = Validation().panopto_id(external_id)
+            return folder_id
+        except InvalidParamException:
+            pass
+
+        try:
             folders = self._session_api.getAllFoldersByExternalId(
                 [external_id])
             if folders and len(folders) and len(folders[0]):


### PR DESCRIPTION
Here is a friendly way I came up with to bulk-copy the schedule from one recorder to another. This will aid the process of bringing a replacement recorder online in case of failure or planned upgrades.

You just open the "Panopto Recorders" admin page and select your new recorder. This recorder's scheduled sessions, if any, will be displayed.
Set the "Location" to be the same as the recorder you're replacing.
Then select the old recorder from the second dropdown. The old recorder's schedule will be added into the displayed list of sessions.
You can then schedule any or all of these sessions onto the new recorder, by using the standard "Schedule" buttons.
