### PR TITLE
Copy scheduled sessions from one recorder to another

### DIFF
--- a/scheduler/static/scheduler/js/main.js
+++ b/scheduler/static/scheduler/js/main.js
@@ -567,6 +567,21 @@ var PanoptoScheduler = (function ($) {
 
     }
 
+    function do_scheduled_recording_search(session_ids) {
+        $.ajax({
+            type: 'GET',
+            url: panopto_api_path('schedule/', {
+                session_ids: session_ids,
+            }),
+            waitIndicatator: event_search_in_progress,
+            complete: event_search_complete
+        })
+            .fail(event_search_failure)
+            .done(function (msg) {
+                paint_space_schedule(msg);
+            });
+    }
+
     function update_term_selector() {
         $('#selected-quarter').html($("option:selected", this).text());
     }
@@ -1245,6 +1260,8 @@ var PanoptoScheduler = (function ($) {
             };
 
         $('.result-display-container').html(tpl(context));
+
+        do_scheduled_recording_search(data[0].scheduled_recordings);
     }
 
     function panopto_recorder_search() {

--- a/scheduler/templates/scheduler/recorders.html
+++ b/scheduler/templates/scheduler/recorders.html
@@ -65,9 +65,65 @@
   {{#each scheduled_recordings}}
   
   {{/each}}
+
+  <div class="event-search">
+    <div class="result-display-container event-search-result"></div>
+  </div>
 </div>
 {% endtplhandlebars %}
 
+{% tplhandlebars "event-search-result-template" %}
+  <div class="result-list-container">
+    <div class="result-header">
+        <span class="sr-only">Schedule in {{room}}</span>
+        <span class="sr-only">Lecture capture recording status: </span>
+        {{#if has_recorder}}
+	    <span class="record-status-enable"><i class="fa fa-video-camera"></i> Recorder is ready in this room</span>
+	    {{else}}
+		<span class="record-status-disable-outer"><i class="fa fa-warning"></i><span class="record-status-disable">No recorder found in this room</span></span>
+	    {{/if}}
+    </div>
+
+    {{> reservation-list}}
+
+  </div>
+{% endtplhandlebars %}
+
+
+{% tplhandlebars "event-search-result-empty-template" %}
+  <div class="room-header"><!-- Rslt Header -->
+	<h3>No events scheduled on this recorder</h3>
+  </div>	<!-- .Rslt Header -->
+{% endtplhandlebars %}
+
+{% tplhandlebars "reservation-list-partial" %}
+  <ol class="list-group result-list-chunk">
+    {{#each schedule}}
+      <li class="list-group-item clearfix">
+        <span class="result-row-date" title="date">{{ month_num }}/{{ day }}</span>
+        <span class="result-row-day" title="day">{{ weekday }}</span>
+        <span class="result-row-time" title="time">{{ event_start_time }} - {{ event_end_time }} {{ ampm }}</span>
+        <span class="result-row-event meeting-room-{{ name_index }}" title="event name">{{ name }}</span>
+        <span class="result-row-contact" title="Contact person">
+          {{#if contact_email}}
+            <a href="mailto:{{ contact_email }}" target="_blank">{{ contact }}</a>
+          {{else}}
+            {{ contact }}
+          {{/if}}
+        </span>
+        {{#if has_recorder}}
+        <!--Button Code-->
+        <span class="pull-right result-row-switchbtn">
+        {{> schedule-button}}
+        </span>
+        <!--End button-->
+        {{/if}}
+      </li>
+    {{/each}}
+  </ol>
+{% endtplhandlebars %}
+
+{% include "scheduler/handlebars/schedule_button_partial.html" %}
 
 {% tplhandlebars "ajax-waiting" %}
   <div class="waiting">
@@ -164,6 +220,7 @@ window.scheduler = {
 {% block extra_js %}
 {% compress js %}
 <script src="{% static "vendor/js/moment.min.js" %}"></script>
+<script src="{% static "vendor/js/bootstrap-slider.min.js" %}"></script>
 <script src="{% static "scheduler/js/main.js" %}"></script>
 {% endcompress %}
 {% endblock extra_js %}

--- a/scheduler/utils/__init__.py
+++ b/scheduler/utils/__init__.py
@@ -298,7 +298,7 @@ def event_session_from_scheduled_recording(s):
             'folder': {
                 'name': s.FolderName,
                 'id': s.FolderId,
-                'external_id': '',
+                'external_id': s.FolderId,
             },
             'is_broadcast': s.IsBroadcast,
             'is_public': False,

--- a/scheduler/utils/__init__.py
+++ b/scheduler/utils/__init__.py
@@ -11,6 +11,7 @@ from restclients.r25.reservations import get_reservations
 from restclients.canvas.courses import Courses as CanvasCourses
 from scheduler.utils.recorder import get_recorder_details, RecorderException
 from scheduler.utils.session import get_sessions_by_external_ids
+from scheduler.utils.session import get_sessions_by_session_ids
 from panopto_client.access import AccessManagement
 from panopto_client import PanoptoAPIException
 from dateutil import parser, tz
@@ -124,10 +125,9 @@ def course_recording_sessions(course, event):
 def space_events_and_recordings(params):
     search = {
         'space_id': params.get('space_id'),
-        'start_dt': params.get('start_dt')
+        'start_dt': params.get('start_dt'),
+        'session_ids': params.get('session_ids'),
     }
-
-    start_dt = parser.parse(search['start_dt']).date()
 
     current_term = get_current_term()
     next_term = get_next_term()
@@ -138,7 +138,19 @@ def space_events_and_recordings(params):
         search['space_id']: params.get('recorder_id')
     }
 
+    if search['session_ids']:
+        sessions = get_sessions_by_session_ids(
+            search['session_ids'].split(','))
+
+        for s in sessions:
+            event_session = event_session_from_scheduled_recording(s)
+            event_sessions.append(event_session)
+
+        return event_sessions
+
     if search['space_id'] and search['start_dt']:
+        start_dt = parser.parse(search['start_dt']).date()
+
         reservations = get_reservations(**search)
 
         # build event sessions, accounting for joint class reservations
@@ -259,6 +271,55 @@ def event_session_from_reservation(r):
 
     session['recording']['start'] = start_utc.isoformat()
     session['recording']['end'] = end_utc.isoformat()
+
+    return session
+
+
+def event_session_from_scheduled_recording(s):
+    start_utc = s.StartTime.astimezone(pytz.utc)
+    end_utc = start_utc + datetime.timedelta(seconds=int(s.Duration))
+
+    session = {
+        'profile': '',
+        'name': s.Name,
+        'schedulable': True,
+        'space': {
+            'id': None,
+            'name': None,
+            'formal_name': None
+        },
+        'recording': {
+            'name': s.Name,
+            'id': s.Id,
+            'external_id': s.ExternalId,
+            'recorder_id': s.RemoteRecorderIds.guid[0],
+            'start': start_utc.isoformat(),
+            'end': end_utc.isoformat(),
+            'folder': {
+                'name': s.FolderName,
+                'id': s.FolderId,
+                'external_id': '',
+            },
+            'is_broadcast': s.IsBroadcast,
+            'is_public': False,
+        },
+        'contact': {
+            'name': '',
+            'uwnetid': '',
+            'email': '',
+        },
+        'event': {
+            'start': start_utc.isoformat(),
+            'end': end_utc.isoformat(),
+        }
+    }
+
+    session['key'] = course_event_key(
+        session['contact']['uwnetid'],
+        session['recording']['name'],
+        session['recording']['external_id'],
+        session['recording']['recorder_id'],
+        session['recording']['folder']['external_id'])
 
     return session
 

--- a/scheduler/utils/session.py
+++ b/scheduler/utils/session.py
@@ -6,3 +6,10 @@ def get_sessions_by_external_ids(external_ids):
     sessions = api.getSessionsByExternalId(external_ids)
     return sessions.Session if (sessions and 'Session' in sessions and
                                 len(sessions.Session)) else None
+
+
+def get_sessions_by_session_ids(session_ids):
+    api = SessionManagement()
+    sessions = api.getSessionsById(session_ids)
+    return sessions.Session if (sessions and 'Session' in sessions and
+                                len(sessions.Session)) else None

--- a/scheduler/views/api/session.py
+++ b/scheduler/views/api/session.py
@@ -144,6 +144,12 @@ class Session(RESTDispatch):
 
     def _valid_folder(self, name, external_id):
         try:
+            folder_id = Validation().panopto_id(external_id)
+            return folder_id
+        except InvalidParamException:
+            pass
+
+        try:
             folders = self._session_api.getAllFoldersByExternalId(
                 [external_id])
             if folders and len(folders) and len(folders[0]):


### PR DESCRIPTION
Here is a friendly way I came up with to bulk-copy the schedule from one recorder to another. This will aid the process of bringing a replacement recorder online in case of failure or planned upgrades.

You just open the "Panopto Recorders" admin page and select your new recorder. This recorder's scheduled sessions, if any, will be displayed.
Set the "Location" to be the same as the recorder you're replacing.
Then select the old recorder from the second dropdown. The old recorder's schedule will be added into the displayed list of sessions.
You can then schedule any or all of these sessions onto the new recorder, by using the standard "Schedule" buttons.
